### PR TITLE
Implement motor commands, wheel telemetry

### DIFF
--- a/.github/workflows/hardware-check.yaml
+++ b/.github/workflows/hardware-check.yaml
@@ -3,19 +3,30 @@ name: Hardware Check
 on:
   push:
     branches: ["main"]
-    paths:
-      - 'mote-hardware/**'
   pull_request:
     branches: ["main"]
-    paths:
-      - 'mote-hardware/**'
 
 defaults:
   run:
     shell: bash
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      hardware: ${{ steps.filter.outputs.hardware }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            hardware:
+              - 'mote-hardware/**'
+
   drc:
+    needs: filter
+    if: needs.filter.outputs.hardware == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/inti-cmnb/kicad9_auto:latest

--- a/mote-api/examples/rerun_viz.rs
+++ b/mote-api/examples/rerun_viz.rs
@@ -128,7 +128,7 @@ fn main() -> anyhow::Result<()> {
                             )
                             .unwrap();
                         }
-                        mote_to_host::Message::State(_) => todo!(),
+                        _ => todo!(),
                     }
                 }
             }

--- a/mote-api/examples/rerun_viz.rs
+++ b/mote-api/examples/rerun_viz.rs
@@ -104,7 +104,7 @@ fn main() -> anyhow::Result<()> {
                             let points: Vec<glam::Vec2> = scan_data
                                 .iter()
                                 .map(|point| {
-                                    glam::Vec2::from_angle(point.angle_rads) * point.distance_mm
+                                    glam::Vec2::from_angle(point.angle_rad) * point.distance_mm
                                 })
                                 .collect();
 

--- a/mote-api/src/lib.rs
+++ b/mote-api/src/lib.rs
@@ -197,12 +197,12 @@ mod tests {
             mote_to_host::Message::Scan(vec![
                 mote_to_host::Point {
                     quality: 255,
-                    angle_rads: 1.5707,
+                    angle_rad: 1.5707,
                     distance_mm: 500.0,
                 },
                 mote_to_host::Point {
                     quality: 0,
-                    angle_rads: 0.0,
+                    angle_rad: 0.0,
                     distance_mm: 0.0,
                 },
             ]),
@@ -354,7 +354,7 @@ mod tests {
             (0..100u8)
                 .map(|i| mote_to_host::Point {
                     quality: i,
-                    angle_rads: i as f32 * 0.01,
+                    angle_rad: i as f32 * 0.01,
                     distance_mm: i as f32 * 10.0,
                 })
                 .collect(),

--- a/mote-api/src/messages/host_to_mote.rs
+++ b/mote-api/src/messages/host_to_mote.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 
-// RUNTIME MESSAGES
+// CONFIGURATION MESSAGES
 
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -21,24 +21,14 @@ pub struct SetUID {
     pub uid: String,
 }
 
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[derive(Serialize, Deserialize, Debug)]
-pub enum Subsystem {
-    Lidar,
-    Imu,
-    DriveBase,
-}
+// RUNTIME MESSAGES
 
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[derive(Serialize, Deserialize, Debug)]
-pub struct SetEnabled {
-    pub subsystem: Subsystem,
-    pub enable: bool,
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct SetDriveBaseVelocity {
+    pub left_velocity_rad: f32,
+    pub right_velocity_rad: f32,
 }
-
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[derive(Serialize, Deserialize, Debug)]
-pub struct SoftReset;
 
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -48,4 +38,5 @@ pub enum Message {
     RequestNetworkScan,
     SetNetworkConnectionConfig(SetNetworkConnectionConfig),
     SetUID(SetUID),
+    DriveBaseCommand(SetDriveBaseVelocity),
 }

--- a/mote-api/src/messages/mote_to_host.rs
+++ b/mote-api/src/messages/mote_to_host.rs
@@ -13,8 +13,40 @@ use schemars::JsonSchema;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Point {
     pub quality: u8,
-    pub angle_rads: f32,
+    pub angle_rad: f32,
     pub distance_mm: f32,
+}
+
+// Encoder / Drive Base Data
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct WheelJointState {
+    pub effort_percent: f32,
+    pub velocity_rad_per_s: f32,
+    pub postition_rad: f32,
+}
+
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct DriveBaseState {
+    pub left: WheelJointState,
+    pub right: WheelJointState,
+}
+
+// IMU Data
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct IMUAxisTriple {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct IMUMeasurement {
+    pub accel: IMUAxisTriple,
+    pub gyro: IMUAxisTriple,
 }
 
 // CONFIGURATION MESSAGES
@@ -70,5 +102,7 @@ pub enum Message {
     Ping,
     Pong,
     Scan(Vec<Point>),
+    DriveBaseState(DriveBaseState),
+    IMUMeasurement(IMUMeasurement),
     State(State),
 }

--- a/mote-configuration/package-lock.json
+++ b/mote-configuration/package-lock.json
@@ -24,7 +24,7 @@
         },
         "../mote-ffi/target/pkg-node": {
             "name": "mote-ffi",
-            "version": "0.1.0"
+            "version": "0.0.0"
         },
         "node_modules/@apidevtools/json-schema-ref-parser": {
             "version": "11.9.3",

--- a/mote-ffi/mote_link/examples/rerun_demo.py
+++ b/mote-ffi/mote_link/examples/rerun_demo.py
@@ -3,15 +3,45 @@ import colorsys
 import math
 
 import rerun as rr
+import rerun.blueprint as rrb
 
-from mote_link.link import MoteClient, MoteConnectionError, Ping, Pong, Scan, State
+from mote_link.link import (
+    DriveBaseState,
+    IMUMeasurement,
+    MoteClient,
+    MoteConnectionError,
+    Ping,
+    Pong,
+    Scan,
+    SetDriveBaseVelocity,
+    State,
+)
+
+
+def _log_drive_base_state(state: DriveBaseState):
+    for side, wheel in [("left", state.left), ("right", state.right)]:
+        rr.log(f"drive_base/{side}/effort_percent", rr.Scalars(wheel.effort_percent))
+        rr.log(
+            f"drive_base/{side}/velocity_rad_per_s",
+            rr.Scalars(wheel.velocity_rad_per_s),
+        )
+        rr.log(f"drive_base/{side}/position_rad", rr.Scalars(wheel.postition_rad))
+
+
+def _log_imu_measurement(imu: IMUMeasurement):
+    rr.log("imu/accel/x", rr.Scalars(imu.accel.x))
+    rr.log("imu/accel/y", rr.Scalars(imu.accel.y))
+    rr.log("imu/accel/z", rr.Scalars(imu.accel.z))
+    rr.log("imu/gyro/x", rr.Scalars(imu.gyro.x))
+    rr.log("imu/gyro/y", rr.Scalars(imu.gyro.y))
+    rr.log("imu/gyro/z", rr.Scalars(imu.gyro.z))
 
 
 def _log_scan(scan: Scan):
     positions = [
         [
-            math.cos(p.angle_rads) * p.distance_mm,
-            math.sin(p.angle_rads) * p.distance_mm,
+            math.cos(p.angle_rad) * p.distance_mm,
+            math.sin(p.angle_rad) * p.distance_mm,
         ]
         for p in scan.points
     ]
@@ -33,24 +63,131 @@ async def run_main():
     server_uri = rr.serve_grpc()
     rr.serve_web_viewer(connect_to=server_uri)
 
+    wheel_time_ranges = [
+        rrb.VisibleTimeRange(
+            "log_time",
+            start=rrb.TimeRangeBoundary.cursor_relative(seconds=-10.0),
+            end=rrb.TimeRangeBoundary.cursor_relative(seconds=5.0),
+        )
+    ]
+
+    # (row label, {side: [entity paths]})
+    wheel_signal_rows = [
+        (
+            "Velocity",
+            {
+                side: [
+                    f"+ /drive_base/{side}/velocity_rad_per_s",
+                    f"+ /drive_base/{side}/velocity_command_rad_per_s",
+                ]
+                for side in ("left", "right")
+            },
+        ),
+        (
+            "Effort",
+            {
+                side: [f"+ /drive_base/{side}/effort_percent"]
+                for side in ("left", "right")
+            },
+        ),
+        (
+            "Position",
+            {
+                side: [f"+ /drive_base/{side}/position_rad"]
+                for side in ("left", "right")
+            },
+        ),
+    ]
+
+    wheel_rows = [
+        rrb.Horizontal(
+            *[
+                rrb.TimeSeriesView(
+                    name=f"{side.capitalize()} Wheel {label}",
+                    contents=paths,
+                    time_ranges=wheel_time_ranges,
+                )
+                for side, paths in signals.items()
+            ]
+        )
+        for label, signals in wheel_signal_rows
+    ]
+
+    blueprint = rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Spatial2DView(
+                name="LiDAR",
+                origin="/lidar_scan",
+                visual_bounds=rrb.VisualBounds2D(
+                    x_range=[-7000, 7000], y_range=[-7000, 7000]
+                ),
+                time_ranges=[
+                    rrb.VisibleTimeRange(
+                        "log_time",
+                        start=rrb.TimeRangeBoundary.cursor_relative(seconds=-0.2),
+                        end=rrb.TimeRangeBoundary.cursor_relative(),
+                    )
+                ],
+            ),
+            rrb.Vertical(
+                # rrb.TimeSeriesView(name="Accel", origin="/imu/accel"),
+                # rrb.TimeSeriesView(name="Gyro", origin="/imu/gyro"),
+                *wheel_rows,
+            ),
+        ),
+        rrb.SelectionPanel(state="collapsed"),
+        rrb.TimePanel(state="collapsed"),
+    )
+    rr.send_blueprint(blueprint)
+
     async with MoteClient() as client:
         await client.connect()
 
         print("Pinging Mote")
         await client.send(Ping())
 
-        while True:
-            message = await client.recv()
+        async def recv_loop():
+            while True:
+                message = await client.recv()
 
-            if isinstance(message, Pong):
-                print("Got pong from Mote.")
-            elif isinstance(message, Ping):
-                print("Mote pinged host.")
-                await client.send(Pong())
-            elif isinstance(message, Scan):
-                _log_scan(message)
-            elif isinstance(message, State):
-                print(f"Got system state {message}")
+                if isinstance(message, Pong):
+                    print("Got pong from Mote.")
+                elif isinstance(message, Ping):
+                    print("Mote pinged host.")
+                    await client.send(Pong())
+                elif isinstance(message, Scan):
+                    _log_scan(message)
+                elif isinstance(message, DriveBaseState):
+                    _log_drive_base_state(message)
+                elif isinstance(message, IMUMeasurement):
+                    _log_imu_measurement(message)
+                elif isinstance(message, State):
+                    print(f"Got system state {message}")
+
+        async def sine_wave_command_loop():
+            amplitude = 3.0  # rad/s
+            period = 4.0  # seconds
+            dt = 0.05  # 20 Hz command rate
+            t = 0.0
+            while True:
+                velocity = amplitude * math.sin(2 * math.pi * t / period)
+                await client.send(
+                    SetDriveBaseVelocity(
+                        left_velocity_rad=velocity,
+                        right_velocity_rad=-velocity,
+                    )
+                )
+                rr.log(
+                    "drive_base/left/velocity_command_rad_per_s", rr.Scalars(velocity)
+                )
+                rr.log(
+                    "drive_base/right/velocity_command_rad_per_s",
+                    rr.Scalars(-velocity),
+                )
+                t += dt
+                await asyncio.sleep(dt)
+
+        await asyncio.gather(recv_loop(), sine_wave_command_loop())
 
 
 def main():

--- a/mote-ffi/mote_link/link.py
+++ b/mote-ffi/mote_link/link.py
@@ -21,8 +21,6 @@ class MoteConnectionError(Exception):
 
 
 # Message types
-
-
 @dataclass
 class LidarPoint:
     quality: int

--- a/mote-ffi/mote_link/link.py
+++ b/mote-ffi/mote_link/link.py
@@ -24,7 +24,7 @@ class MoteConnectionError(Exception):
 @dataclass
 class LidarPoint:
     quality: int
-    angle_rads: float
+    angle_rad: float
     distance_mm: float
 
 
@@ -91,6 +91,38 @@ class SetUID:
 
 
 @dataclass
+class WheelJointState:
+    effort_percent: float
+    velocity_rad_per_s: float
+    postition_rad: float
+
+
+@dataclass
+class DriveBaseState:
+    left: WheelJointState
+    right: WheelJointState
+
+
+@dataclass
+class IMUAxisTriple:
+    x: float
+    y: float
+    z: float
+
+
+@dataclass
+class IMUMeasurement:
+    accel: IMUAxisTriple
+    gyro: IMUAxisTriple
+
+
+@dataclass
+class SetDriveBaseVelocity:
+    left_velocity_rad: float
+    right_velocity_rad: float
+
+
+@dataclass
 class Scan:
     points: list[LidarPoint]
 
@@ -101,10 +133,17 @@ class State:
 
 
 # Union of all messages the host can send to Mote
-HostMessage = Union[Ping, Pong, RequestNetworkScan, SetNetworkConnectionConfig, SetUID]
+HostMessage = Union[
+    Ping,
+    Pong,
+    RequestNetworkScan,
+    SetNetworkConnectionConfig,
+    SetUID,
+    SetDriveBaseVelocity,
+]
 
 # Union of all messages Mote can send to the host
-MoteMessage = Union[Ping, Pong, Scan, State]
+MoteMessage = Union[Ping, Pong, Scan, DriveBaseState, IMUMeasurement, State]
 
 
 # Converts mote_ffi json based messages into Python native types
@@ -121,6 +160,15 @@ def _serialize_host_message(msg: HostMessage) -> str:
         )
     if isinstance(msg, SetUID):
         return json.dumps({"SetUID": {"uid": msg.uid}})
+    if isinstance(msg, SetDriveBaseVelocity):
+        return json.dumps(
+            {
+                "DriveBaseCommand": {
+                    "left_velocity_rad": msg.left_velocity_rad,
+                    "right_velocity_rad": msg.right_velocity_rad,
+                }
+            }
+        )
     raise TypeError(f"Unknown host message type: {type(msg)}")
 
 
@@ -133,6 +181,18 @@ def _deserialize_mote_message(data) -> MoteMessage:
     if isinstance(data, dict):
         if "Scan" in data:
             return Scan(points=[LidarPoint(**p) for p in data["Scan"]])
+        if "DriveBaseState" in data:
+            d = data["DriveBaseState"]
+            return DriveBaseState(
+                left=WheelJointState(**d["left"]),
+                right=WheelJointState(**d["right"]),
+            )
+        if "IMUMeasurement" in data:
+            d = data["IMUMeasurement"]
+            return IMUMeasurement(
+                accel=IMUAxisTriple(**d["accel"]),
+                gyro=IMUAxisTriple(**d["gyro"]),
+            )
         if "State" in data:
             s = data["State"]
             return State(

--- a/mote-ffi/mote_link/tests/test_link.py
+++ b/mote-ffi/mote_link/tests/test_link.py
@@ -3,10 +3,13 @@ import json
 import pytest
 
 from mote_link.link import (
+    DriveBaseState,
+    IMUMeasurement,
     Ping,
     Pong,
     RequestNetworkScan,
     Scan,
+    SetDriveBaseVelocity,
     SetNetworkConnectionConfig,
     SetUID,
     _deserialize_mote_message,
@@ -38,6 +41,13 @@ class TestSerializeHostMessage:
         data = json.loads(_serialize_host_message(SetUID(uid="mote-123")))
         assert data == {"SetUID": {"uid": "mote-123"}}
 
+    def test_drive_base_command(self):
+        msg = SetDriveBaseVelocity(left_velocity_rad=1.5, right_velocity_rad=-0.5)
+        data = json.loads(_serialize_host_message(msg))
+        assert data == {
+            "DriveBaseCommand": {"left_velocity_rad": 1.5, "right_velocity_rad": -0.5}
+        }
+
     def test_unknown_type_raises(self):
         with pytest.raises(TypeError):
             _serialize_host_message("not_a_message")  # type: ignore[arg-type]
@@ -58,10 +68,42 @@ class TestRoundTrip:
 
     def test_scan_points_preserved(self):
         points = [
-            {"quality": 1, "angle_rads": 0.1, "distance_mm": 10.0},
-            {"quality": 2, "angle_rads": 0.2, "distance_mm": 20.0},
+            {"quality": 1, "angle_rad": 0.1, "distance_mm": 10.0},
+            {"quality": 2, "angle_rad": 0.2, "distance_mm": 20.0},
         ]
         result = _deserialize_mote_message({"Scan": points})
         assert isinstance(result, Scan)
         assert len(result.points) == 2
         assert result.points[1].distance_mm == 20.0
+
+    def test_drive_base_state(self):
+        data = {
+            "DriveBaseState": {
+                "left": {
+                    "effort_percent": 0.5,
+                    "velocity_rad_per_s": 1.0,
+                    "postition_rad": 0.0,
+                },
+                "right": {
+                    "effort_percent": 0.3,
+                    "velocity_rad_per_s": 0.8,
+                    "postition_rad": 0.1,
+                },
+            }
+        }
+        result = _deserialize_mote_message(data)
+        assert isinstance(result, DriveBaseState)
+        assert result.left.effort_percent == 0.5
+        assert result.right.velocity_rad_per_s == 0.8
+
+    def test_imu_measurement(self):
+        data = {
+            "IMUMeasurement": {
+                "accel": {"x": 0.1, "y": 0.2, "z": 9.8},
+                "gyro": {"x": 0.01, "y": 0.02, "z": 0.03},
+            }
+        }
+        result = _deserialize_mote_message(data)
+        assert isinstance(result, IMUMeasurement)
+        assert result.accel.z == 9.8
+        assert result.gyro.x == 0.01

--- a/mote-firmware/src/tasks/drive_base.rs
+++ b/mote-firmware/src/tasks/drive_base.rs
@@ -1,6 +1,6 @@
 use defmt::error;
 use embassy_executor::Spawner;
-use embassy_futures::select::{select3, select4};
+use embassy_futures::select::select4;
 use embassy_rp::pio::{Instance, Pio};
 use embassy_rp::pwm::SetDutyCycle;
 use embassy_rp::{gpio, pwm};
@@ -199,8 +199,6 @@ async fn motor_task(
                 // Run PID update
                 left_motor.step(PID_CONTROL_LOOP_PERIOD_MS).await;
                 right_motor.step(PID_CONTROL_LOOP_PERIOD_MS).await;
-                // Push deadline far into the future so it doesn't re-fire immediately
-                watchdog_deadline = Instant::now() + Duration::from_secs(u64::MAX / 2);
             }
             embassy_futures::select::Either4::Second(_) => {
                 // Send a value to the data offload link
@@ -214,6 +212,8 @@ async fn motor_task(
                 sleep.set_low();
                 left_motor.set_setpoint_rad_per_s(0.0);
                 right_motor.set_setpoint_rad_per_s(0.0);
+                // Push deadline far into the future so it doesn't re-fire immediately
+                watchdog_deadline = Instant::now() + Duration::from_secs(10000);
             }
             embassy_futures::select::Either4::Fourth(command) => {
                 // Command received, feed the watchdog

--- a/mote-firmware/src/tasks/drive_base.rs
+++ b/mote-firmware/src/tasks/drive_base.rs
@@ -1,36 +1,56 @@
 use defmt::error;
 use embassy_executor::Spawner;
+use embassy_futures::select::{select3, select4};
 use embassy_rp::pio::{Instance, Pio};
 use embassy_rp::pwm::SetDutyCycle;
 use embassy_rp::{gpio, pwm};
-use embassy_time::{Duration, Ticker};
+use embassy_time::{Duration, Instant, Ticker, Timer};
+use mote_api::messages::mote_to_host::{DriveBaseState, Message, WheelJointState};
 use pid::Pid;
 
 use crate::tasks::drive_base::encoder::PioEncoder;
 use crate::tasks::drive_base::hbridge::PwmBridge;
+use crate::tasks::wifi::{DATA_OFFLOAD_CHANNEL, MOTOR_COMMAND_CHANNEL};
 use crate::tasks::{DRV8833Resources, EncoderDriverResources, Irqs, LeftEncoderResources, RightEncoderResources};
 
 mod encoder;
 mod hbridge;
 
+/// Number of encoder pulses recorded per rotation.
+/// This is specific to each model of TT motor, right now we use:
+/// https://category.yahboom.net/products/encoder-tt-motor?srsltid=AfmBOooIQxn2e-jyW08981J7uv54Ng7IHo0c9PmTH5pefo1hFxmwZq3i
+/// We may want to make this a configurable value to support different motors.
 const ENCODER_PULSES_PER_ROTATION: u16 = 2340;
-const MOTOR_DEADBAND: u8 = 60;
+/// Stiction prevents commands lower than this % from causing motion.
+const MOTOR_DEADBAND_PERCENT: u8 = 60;
+/// PDI commands lower than this % are filtered to prevent chattering due to
+/// gearbox hysteresis.
+const CONTROL_DEADBAND_PERCENT: f32 = 2.;
+/// ms per iteration of the PID control loop.
+const PID_CONTROL_LOOP_PERIOD_MS: u64 = 20;
+/// ms per joint state telemetry value.
+const TELEMETRY_LOOP_PERIOD_MS: u64 = 100;
+/// Seconds of not receiving a command before deactivating the drive base.
+const WATCH_DOG_TIMEOUT: u64 = 1;
 
-fn encoder_pulses_to_rad_per_second(pulses: i32) -> f32 {
+/// Convert encoder pulses into radians
+fn encoder_pulses_to_rad(pulses: i32) -> f32 {
     (pulses as f32 / ENCODER_PULSES_PER_ROTATION as f32) * 2. * core::f32::consts::PI
 }
 
+/// Represents a motor with an hbridge driver and quadrature encoder.
 struct Motor<'d, T: SetDutyCycle, P: Instance, const SM: usize> {
     bridge: PwmBridge<T>,
     pio_encoder: PioEncoder<'d, P, SM>,
     pid: Pid<f32>,
 
     encoder_value: i32,
+    pub joint_state: WheelJointState,
 }
 
 impl<'d, T: SetDutyCycle, P: Instance, const SM: usize> Motor<'d, T, P, SM> {
     fn new(bridge: PwmBridge<T>, encoder: PioEncoder<'d, P, SM>) -> Self {
-        let ouput_limit = 100. - MOTOR_DEADBAND as f32;
+        let ouput_limit = 100. - MOTOR_DEADBAND_PERCENT as f32;
         let pid = *Pid::<f32>::new(0., ouput_limit)
             .p(10.0, ouput_limit)
             .i(1.0, ouput_limit);
@@ -40,48 +60,51 @@ impl<'d, T: SetDutyCycle, P: Instance, const SM: usize> Motor<'d, T, P, SM> {
             pio_encoder: encoder,
             pid,
             encoder_value: 0,
+            joint_state: WheelJointState {
+                effort_percent: 0.0,
+                velocity_rad_per_s: 0.0,
+                postition_rad: 0.0,
+            },
         }
     }
 
-    #[allow(dead_code)]
-    fn set_setpoint(&mut self, setpoint: f32) {
+    /// Set the target velocity in radians/second
+    fn set_setpoint_rad_per_s(&mut self, setpoint: f32) {
         self.pid.setpoint(setpoint);
     }
 
-    async fn step(&mut self, dt_ms: u32) {
+    /// Step the motor's PDI loop, targeting the latest setpoint commanded by
+    /// set_setpoint
+    async fn step(&mut self, dt_ms: u64) {
         let dt = dt_ms as f32 / 1000.;
 
+        // Calculate rotation delta as pulses per second
         let last_encoder_read = self.encoder_value;
         self.encoder_value = self.pio_encoder.read().await;
+        let measurement = encoder_pulses_to_rad(self.encoder_value - last_encoder_read);
 
-        let measurement = encoder_pulses_to_rad_per_second(self.encoder_value - last_encoder_read);
-
+        // Get the PID output accounting for the motor deadband
         let control_output = self.pid.next_control_output(measurement / dt).output;
         let deadband_adjusted_output = if control_output > 0. {
-            control_output + MOTOR_DEADBAND as f32
+            control_output + MOTOR_DEADBAND_PERCENT as f32
         } else {
-            control_output - MOTOR_DEADBAND as f32
+            control_output - MOTOR_DEADBAND_PERCENT as f32
         };
 
-        // info!(
-        //     "Measurement {} | Rad/s {} | Control Output {}",
-        //     measurement,
-        //     measurement / dt,
-        //     control_output
-        // );
-
-        if control_output > 2.0 {
+        // If the command exceeds the control deadband, forward it to the hbridge with
+        // the correct polarity
+        if control_output > CONTROL_DEADBAND_PERCENT {
             self.bridge.forward(deadband_adjusted_output as u8).unwrap();
-        } else if control_output < -2.0 {
+        } else if control_output < -CONTROL_DEADBAND_PERCENT {
             self.bridge.reverse(-deadband_adjusted_output as u8).unwrap();
         } else {
             self.bridge.stop().unwrap();
         }
-    }
 
-    #[allow(dead_code)]
-    fn pio_encoder(&self) -> &PioEncoder<'d, P, SM> {
-        &self.pio_encoder
+        // Update the joint state
+        self.joint_state.postition_rad = encoder_pulses_to_rad(self.encoder_value);
+        self.joint_state.velocity_rad_per_s = measurement / dt;
+        self.joint_state.effort_percent = deadband_adjusted_output;
     }
 }
 
@@ -109,7 +132,7 @@ async fn motor_task(
         ..
     } = Pio::new(encoder_driver_r.pio, Irqs);
 
-    // Left wheel
+    // Configure left wheel
     let left_encoder = PioEncoder::new(
         &mut encoder_common,
         encoder_sm0,
@@ -130,7 +153,7 @@ async fn motor_task(
     let left_pwm_bridge = PwmBridge::new(left_a, left_b, 0);
     let mut left_motor = Motor::new(left_pwm_bridge, left_encoder);
 
-    // Right wheel
+    // Configure right wheel
     let right_encoder = PioEncoder::new(
         &mut encoder_common,
         encoder_sm1,
@@ -151,18 +174,56 @@ async fn motor_task(
     let right_pwm_bridge = PwmBridge::new(right_a, right_b, 0);
     let mut right_motor = Motor::new(right_pwm_bridge, right_encoder);
 
-    let _sleep = gpio::Output::new(motor_driver_r.sleep, gpio::Level::High);
+    // Init sleep pin
+    let mut sleep = gpio::Output::new(motor_driver_r.sleep, gpio::Level::High);
 
-    // Run PID at 50Hz
-    let mut ticker = Ticker::every(Duration::from_millis(20));
+    // PID, telem and watchdog timers
+    let mut pid_ticker = Ticker::every(Duration::from_millis(PID_CONTROL_LOOP_PERIOD_MS));
+    let mut telemetry_ticker = Ticker::every(Duration::from_millis(TELEMETRY_LOOP_PERIOD_MS));
+    let mut watchdog_deadline = Instant::now() + Duration::from_secs(WATCH_DOG_TIMEOUT);
 
-    // left_motor.set_setpoint(5.0);
+    // Motors start with 0 velocity
+    left_motor.set_setpoint_rad_per_s(0.0);
+    right_motor.set_setpoint_rad_per_s(0.0);
 
     loop {
-        left_motor.step(20).await;
-        right_motor.step(20).await;
-
-        ticker.next().await;
+        match select4(
+            pid_ticker.next(),
+            telemetry_ticker.next(),
+            Timer::at(watchdog_deadline),
+            MOTOR_COMMAND_CHANNEL.receive(),
+        )
+        .await
+        {
+            embassy_futures::select::Either4::First(_) => {
+                // Run PID update
+                left_motor.step(PID_CONTROL_LOOP_PERIOD_MS).await;
+                right_motor.step(PID_CONTROL_LOOP_PERIOD_MS).await;
+                // Push deadline far into the future so it doesn't re-fire immediately
+                watchdog_deadline = Instant::now() + Duration::from_secs(u64::MAX / 2);
+            }
+            embassy_futures::select::Either4::Second(_) => {
+                // Send a value to the data offload link
+                let _ = DATA_OFFLOAD_CHANNEL.try_send(Message::DriveBaseState(DriveBaseState {
+                    left: left_motor.joint_state.clone(),
+                    right: right_motor.joint_state.clone(),
+                }));
+            }
+            embassy_futures::select::Either4::Third(_) => {
+                // Watchdog timeout, stop the motors and sleep the drive base
+                sleep.set_low();
+                left_motor.set_setpoint_rad_per_s(0.0);
+                right_motor.set_setpoint_rad_per_s(0.0);
+            }
+            embassy_futures::select::Either4::Fourth(command) => {
+                // Command received, feed the watchdog
+                watchdog_deadline = Instant::now() + Duration::from_secs(WATCH_DOG_TIMEOUT);
+                // Handle the command
+                sleep.set_high();
+                left_motor.set_setpoint_rad_per_s(command.left_velocity_rad);
+                right_motor.set_setpoint_rad_per_s(command.right_velocity_rad);
+            }
+        }
     }
 }
 

--- a/mote-firmware/src/tasks/lidar.rs
+++ b/mote-firmware/src/tasks/lidar.rs
@@ -1,5 +1,6 @@
 mod rp_c1_driver;
 
+use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::uart::{BufferedUart, Config, DataBits, Parity, StopBits};
 use mote_api::messages::mote_to_host;
@@ -73,7 +74,7 @@ async fn lidar_state_machine_task(r: RplidarC1Resources) {
                 match driver.receive_samples(&mut point_buf).await {
                     Ok(count) => {
                         if count < (MAX_POINTS_PER_SCAN_MESSAGE >> 1) {
-                            // More than 50% of points were not read correctly
+                            // More than 50% of points were read incorrectly
                             LidarState::CheckHealth
                         } else {
                             valid_points = count;

--- a/mote-firmware/src/tasks/lidar.rs
+++ b/mote-firmware/src/tasks/lidar.rs
@@ -10,7 +10,7 @@ use super::{Irqs, RplidarC1Resources};
 use crate::helpers::update_bit_result;
 use crate::tasks::CONFIGURATION_STATE;
 use crate::tasks::lidar::rp_c1_driver::{LidarState, Point, RPLidarC1};
-use crate::wifi::MOTE_TO_HOST_DATA_OFFLOAD;
+use crate::wifi::DATA_OFFLOAD_CHANNEL;
 
 const MAX_POINTS_PER_SCAN_MESSAGE: usize = 100;
 
@@ -18,8 +18,8 @@ impl From<Point> for mote_to_host::Point {
     fn from(value: Point) -> Self {
         mote_to_host::Point {
             quality: value.quality,
-            // Feels expensive, but the RP2350 has a FPU
-            angle_rads: (value.angle as f32 / 64.0).to_radians(),
+            // Feels expensive, but the RP2354 has a FPU so probably fine
+            angle_rad: (value.angle as f32 / 64.0).to_radians(),
             distance_mm: value.distance as f32 / 4.0,
         }
     }
@@ -89,7 +89,7 @@ async fn lidar_state_machine_task(r: RplidarC1Resources) {
             LidarState::ProcessSample => {
                 // We don't care if these packets get lost, so don't block if the channel is
                 // full
-                let _ = MOTE_TO_HOST_DATA_OFFLOAD.try_send(mote_to_host::Message::Scan(
+                let _ = DATA_OFFLOAD_CHANNEL.try_send(mote_to_host::Message::Scan(
                     point_buf[..valid_points].iter().map(|&point| point.into()).collect(),
                 ));
 

--- a/mote-firmware/src/tasks/lidar.rs
+++ b/mote-firmware/src/tasks/lidar.rs
@@ -1,6 +1,5 @@
 mod rp_c1_driver;
 
-use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::uart::{BufferedUart, Config, DataBits, Parity, StopBits};
 use mote_api::messages::mote_to_host;

--- a/mote-firmware/src/tasks/wifi.rs
+++ b/mote-firmware/src/tasks/wifi.rs
@@ -12,8 +12,8 @@ use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::Pio;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
-use mote_api::messages::mote_to_host;
 use mote_api::messages::mote_to_host::{BIT, BITResult};
+use mote_api::messages::{host_to_mote, mote_to_host};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -21,7 +21,9 @@ use super::{Cyw43Resources, Irqs};
 use crate::helpers::update_bit_result;
 use crate::tasks::CONFIGURATION_STATE;
 
-pub static MOTE_TO_HOST_DATA_OFFLOAD: Channel<CriticalSectionRawMutex, mote_to_host::Message, 32> = Channel::new();
+pub static DATA_OFFLOAD_CHANNEL: Channel<CriticalSectionRawMutex, mote_to_host::Message, 32> = Channel::new();
+pub static MOTOR_COMMAND_CHANNEL: Channel<CriticalSectionRawMutex, host_to_mote::SetDriveBaseVelocity, 5> =
+    Channel::new();
 
 #[embassy_executor::task]
 async fn cyw43_task(runner: cyw43::Runner<'static, Output<'static>, PioSpi<'static, PIO0, 0, DMA_CH0>>) -> ! {

--- a/mote-firmware/src/tasks/wifi/udp_server.rs
+++ b/mote-firmware/src/tasks/wifi/udp_server.rs
@@ -8,11 +8,11 @@ use mote_api::messages::{host_to_mote, mote_to_host};
 
 use crate::helpers::update_bit_result;
 use crate::tasks::CONFIGURATION_STATE;
-use crate::tasks::wifi::DATA_OFFLOAD_CHANNEL;
+use crate::tasks::wifi::{DATA_OFFLOAD_CHANNEL, MOTOR_COMMAND_CHANNEL};
 
 pub const UDP_SERVER_PORT: u16 = 7475;
 
-fn handle_command(rx_message: &host_to_mote::Message, link: &mut HostLink) {
+async fn handle_command(rx_message: host_to_mote::Message, link: &mut HostLink) {
     match rx_message {
         host_to_mote::Message::Ping => {
             info!("Parsed ping request, responding.");
@@ -20,6 +20,9 @@ fn handle_command(rx_message: &host_to_mote::Message, link: &mut HostLink) {
         }
         host_to_mote::Message::Pong => {
             info!("Received ping response from host.");
+        }
+        host_to_mote::Message::DriveBaseCommand(cmd) => {
+            MOTOR_COMMAND_CHANNEL.send(cmd).await;
         }
         _ => {
             error!("Received unhandled message type");
@@ -69,7 +72,7 @@ pub async fn udp_server_task(stack: Stack<'static>) -> ! {
 
                 link.handle_receive(&message_buffer[..bytes_read]);
                 while let Ok(Some(message)) = link.poll_receive() {
-                    handle_command(&message, &mut link);
+                    handle_command(message, &mut link).await;
                 }
 
                 while let Some(payload) = link.poll_transmit() {

--- a/mote-firmware/src/tasks/wifi/udp_server.rs
+++ b/mote-firmware/src/tasks/wifi/udp_server.rs
@@ -8,7 +8,7 @@ use mote_api::messages::{host_to_mote, mote_to_host};
 
 use crate::helpers::update_bit_result;
 use crate::tasks::CONFIGURATION_STATE;
-use crate::tasks::wifi::MOTE_TO_HOST_DATA_OFFLOAD;
+use crate::tasks::wifi::DATA_OFFLOAD_CHANNEL;
 
 pub const UDP_SERVER_PORT: u16 = 7475;
 
@@ -44,12 +44,7 @@ pub async fn udp_server_task(stack: Stack<'static>) -> ! {
     let mut client: Option<UdpMetadata> = None;
 
     loop {
-        match select(
-            socket.recv_from(&mut message_buffer),
-            MOTE_TO_HOST_DATA_OFFLOAD.receive(),
-        )
-        .await
-        {
+        match select(socket.recv_from(&mut message_buffer), DATA_OFFLOAD_CHANNEL.receive()).await {
             Either::First(Ok((bytes_read, ep))) => {
                 let new_client = match client {
                     None => {


### PR DESCRIPTION
Implements the motor control / data offload pipeline + updates the rerun example to display the data.
Drive by fixes:
* DRC check was using a top level filter which was causing the action to hang on PR
* Add IMU message types to mote-api and related tooling.