### PR TITLE
Auto icmp + power gate fixes

### DIFF
--- a/mote-firmware/Cargo.toml
+++ b/mote-firmware/Cargo.toml
@@ -40,6 +40,7 @@ embassy-net = { version = "0.9", features = [
     "proto-ipv4",
     "proto-ipv6",
     "multicast",
+    "auto-icmp-echo-reply",
 ] }
 embassy-usb = { version = "0.6", features = ["defmt"] }
 embassy-futures = { version = "0.1" }

--- a/mote-firmware/src/main.rs
+++ b/mote-firmware/src/main.rs
@@ -122,16 +122,8 @@ async fn core1_task(
     power_gate::init(spawner, usb_power_r).await;
     info!("Power Gate INIT complete");
 
-    info!("Gating on 1.5A capable before starting LiDAR");
-    power_gate::gate_1_5_amp().await;
-    info!("Power supply is 1.5A capable");
-
     lidar::init(spawner, lidar_r).await;
     info!("LiDAR INIT complete");
-
-    info!("Gating on 3A capable before starting drive base");
-    power_gate::gate_3_amp().await;
-    info!("Power supply is 3A capable");
 
     drive_base::init(
         spawner,

--- a/mote-firmware/src/tasks/drive_base.rs
+++ b/mote-firmware/src/tasks/drive_base.rs
@@ -1,4 +1,4 @@
-use defmt::error;
+use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_futures::select::select4;
 use embassy_rp::pio::{Instance, Pio};
@@ -11,7 +11,9 @@ use pid::Pid;
 use crate::tasks::drive_base::encoder::PioEncoder;
 use crate::tasks::drive_base::hbridge::PwmBridge;
 use crate::tasks::wifi::{DATA_OFFLOAD_CHANNEL, MOTOR_COMMAND_CHANNEL};
-use crate::tasks::{DRV8833Resources, EncoderDriverResources, Irqs, LeftEncoderResources, RightEncoderResources};
+use crate::tasks::{
+    DRV8833Resources, EncoderDriverResources, Irqs, LeftEncoderResources, RightEncoderResources, power_gate,
+};
 
 mod encoder;
 mod hbridge;
@@ -115,6 +117,10 @@ async fn motor_task(
     right_encoder_r: RightEncoderResources,
     motor_driver_r: DRV8833Resources,
 ) {
+    info!("Gating on 3A capable before starting drive base");
+    power_gate::gate_3_amp().await;
+    info!("Power supply is 3A capable");
+
     // Setup PWM
     let desired_freq_hz = 25_000;
     let clock_freq_hz = embassy_rp::clocks::clk_sys_freq();

--- a/mote-firmware/src/tasks/lidar.rs
+++ b/mote-firmware/src/tasks/lidar.rs
@@ -27,6 +27,22 @@ impl From<Point> for mote_to_host::Point {
 
 #[embassy_executor::task]
 async fn lidar_state_machine_task(r: RplidarC1Resources) {
+    // Init BIT
+    {
+        let mut configuration_state = CONFIGURATION_STATE.lock().await;
+        let init = BIT {
+            name: "Init".into(),
+            result: BITResult::Waiting,
+        };
+        let check_health = BIT {
+            name: "Check Health".into(),
+            result: BITResult::Waiting,
+        };
+        for test in [init, check_health] {
+            configuration_state.built_in_test.lidar.push(test);
+        }
+    }
+
     let mut config = Config::default();
     config.baudrate = 460800;
     config.stop_bits = StopBits::STOP1;
@@ -45,6 +61,12 @@ async fn lidar_state_machine_task(r: RplidarC1Resources) {
     let mut valid_points = 0;
 
     let mut driver = RPLidarC1::new(uart);
+
+    // Update init state
+    {
+        let mut configuration_state = CONFIGURATION_STATE.lock().await;
+        update_bit_result(&mut configuration_state.built_in_test.lidar, "Init", BITResult::Pass);
+    }
 
     loop {
         state = match state {
@@ -101,28 +123,6 @@ async fn lidar_state_machine_task(r: RplidarC1Resources) {
 }
 
 pub async fn init(spawner: Spawner, r: RplidarC1Resources) {
-    // Init BIT
-    {
-        let mut configuration_state = CONFIGURATION_STATE.lock().await;
-        let init = BIT {
-            name: "Init".into(),
-            result: BITResult::Waiting,
-        };
-        let check_health = BIT {
-            name: "Check Health".into(),
-            result: BITResult::Waiting,
-        };
-        for test in [init, check_health] {
-            configuration_state.built_in_test.lidar.push(test);
-        }
-    }
-
     // Start task
     spawner.spawn(lidar_state_machine_task(r).unwrap());
-
-    // Update init state
-    {
-        let mut configuration_state = CONFIGURATION_STATE.lock().await;
-        update_bit_result(&mut configuration_state.built_in_test.lidar, "Init", BITResult::Pass);
-    }
 }

--- a/mote-firmware/src/tasks/lidar.rs
+++ b/mote-firmware/src/tasks/lidar.rs
@@ -1,5 +1,6 @@
 mod rp_c1_driver;
 
+use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::uart::{BufferedUart, Config, DataBits, Parity, StopBits};
 use mote_api::messages::mote_to_host;
@@ -8,8 +9,8 @@ use static_cell::StaticCell;
 
 use super::{Irqs, RplidarC1Resources};
 use crate::helpers::update_bit_result;
-use crate::tasks::CONFIGURATION_STATE;
 use crate::tasks::lidar::rp_c1_driver::{LidarState, Point, RPLidarC1};
+use crate::tasks::{CONFIGURATION_STATE, power_gate};
 use crate::wifi::DATA_OFFLOAD_CHANNEL;
 
 const MAX_POINTS_PER_SCAN_MESSAGE: usize = 100;
@@ -42,6 +43,10 @@ async fn lidar_state_machine_task(r: RplidarC1Resources) {
             configuration_state.built_in_test.lidar.push(test);
         }
     }
+
+    info!("Gating on 1.5A capable before starting LiDAR");
+    power_gate::gate_1_5_amp().await;
+    info!("Power supply is 1.5A capable");
 
     let mut config = Config::default();
     config.baudrate = 460800;

--- a/mote-firmware/src/tasks/power_gate.rs
+++ b/mote-firmware/src/tasks/power_gate.rs
@@ -37,6 +37,26 @@ static POWER_GATE_WATCH: Watch<CriticalSectionRawMutex, PowerState, 3> = Watch::
 
 #[embassy_executor::task]
 async fn power_gate_task(r: UsbPowerDetectionResources) -> ! {
+    // Init BIT
+    {
+        let mut configuration_state = CONFIGURATION_STATE.lock().await;
+        let init = BIT {
+            name: "Init".into(),
+            result: BITResult::Pass,
+        };
+        let comms_power = BIT {
+            name: "7.5W Capable (enables WIFI)".into(),
+            result: BITResult::Waiting,
+        };
+        let motor_power = BIT {
+            name: "15W Capable (enables drive base)".into(),
+            result: BITResult::Waiting,
+        };
+        for test in [init, comms_power, motor_power] {
+            configuration_state.built_in_test.power.push(test);
+        }
+    }
+
     let mut adc = Adc::new(r.adc, Irqs, Config::default());
     let mut cc1 = Channel::new_pin(r.cc1, Pull::Down);
     let mut cc2 = Channel::new_pin(r.cc2, Pull::Down);
@@ -94,26 +114,6 @@ async fn power_gate_task(r: UsbPowerDetectionResources) -> ! {
 }
 
 pub async fn init(spawner: Spawner, r: UsbPowerDetectionResources) {
-    // Init BIT
-    {
-        let mut configuration_state = CONFIGURATION_STATE.lock().await;
-        let init = BIT {
-            name: "Init".into(),
-            result: BITResult::Pass,
-        };
-        let comms_power = BIT {
-            name: "7.5W Capable (enables WIFI)".into(),
-            result: BITResult::Waiting,
-        };
-        let motor_power = BIT {
-            name: "15W Capable (enables drive base)".into(),
-            result: BITResult::Waiting,
-        };
-        for test in [init, comms_power, motor_power] {
-            configuration_state.built_in_test.power.push(test);
-        }
-    }
-
     spawner.spawn(power_gate_task(r).unwrap());
 }
 

--- a/mote-firmware/src/tasks/power_gate.rs
+++ b/mote-firmware/src/tasks/power_gate.rs
@@ -1,5 +1,6 @@
 use core::cmp::{max, min};
 
+use defmt::{Format, debug, trace};
 use embassy_executor::Spawner;
 use embassy_rp::adc::{Adc, Channel, Config};
 use embassy_rp::gpio::Pull;
@@ -11,7 +12,7 @@ use mote_api::messages::mote_to_host::{BIT, BITResult};
 use crate::helpers::update_bit_result;
 use crate::tasks::{CONFIGURATION_STATE, Irqs, UsbPowerDetectionResources};
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug, Format)]
 enum PowerState {
     Invalid,
     Disconnected,
@@ -23,11 +24,12 @@ enum PowerState {
 impl From<u16> for PowerState {
     fn from(value: u16) -> Self {
         let v = (value as f32 * 3.3) / 4096.0;
+        trace!("Read power state voltage: {}", v);
         match v {
-            v if v > 0.0 && v < 0.15 => Self::Disconnected,
-            v if v > 0.25 && v < 0.61 => Self::Max500ma,
-            v if v > 0.70 && v < 1.16 => Self::Max1_5a,
-            v if v > 1.31 => Self::Max3a,
+            v if (0.0..=0.15).contains(&v) => Self::Disconnected,
+            v if (0.15..=0.61).contains(&v) => Self::Max500ma,
+            v if (0.61..=1.16).contains(&v) => Self::Max1_5a,
+            v if v > 1.16 => Self::Max3a,
             _ => Self::Invalid,
         }
     }
@@ -73,7 +75,7 @@ async fn power_gate_task(r: UsbPowerDetectionResources) -> ! {
         let upper = PowerState::from(max(cc1_reading, cc2_reading));
 
         // https://global.discourse-cdn.com/digikey/original/3X/c/9/c9109631c71df719fc2dd3c426ccf3c69949f388.png
-        let state = match (lower, upper) {
+        let state = match (&lower, &upper) {
             (PowerState::Invalid, _) => PowerState::Invalid,
             (_, PowerState::Invalid) => PowerState::Invalid,
             (PowerState::Disconnected, PowerState::Disconnected) => PowerState::Disconnected,
@@ -82,6 +84,10 @@ async fn power_gate_task(r: UsbPowerDetectionResources) -> ! {
             (PowerState::Disconnected, PowerState::Max3a) => PowerState::Max3a,
             _ => PowerState::Invalid,
         };
+        debug!(
+            "Read power state {} from {} and {} with raw readings {} and {}",
+            state, lower, upper, cc1_reading, cc2_reading
+        );
 
         if state != last_state {
             {

--- a/mote-firmware/src/tasks/wifi.rs
+++ b/mote-firmware/src/tasks/wifi.rs
@@ -124,14 +124,6 @@ pub async fn init(spawner: Spawner, r: Cyw43Resources) {
     );
     defmt::info!("MAC address: {}", mac_str.as_str());
 
-    {
-        // Update init state
-        let mut configuration_state = CONFIGURATION_STATE.lock().await;
-        update_bit_result(&mut configuration_state.built_in_test.wifi, "Init", BITResult::Pass);
-        // Update mac address
-        configuration_state.mac = Some(mac_str);
-    }
-
     let config = Config::dhcpv4(Default::default());
 
     // Generate random seed
@@ -140,6 +132,14 @@ pub async fn init(spawner: Spawner, r: Cyw43Resources) {
     // Init network stack
     static RESOURCES: StaticCell<StackResources<4>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(net_device, config, RESOURCES.init(StackResources::new()), seed);
+
+    {
+        // Update init state
+        let mut configuration_state = CONFIGURATION_STATE.lock().await;
+        update_bit_result(&mut configuration_state.built_in_test.wifi, "Init", BITResult::Pass);
+        // Update mac address
+        configuration_state.mac = Some(mac_str);
+    }
 
     // Start network task
     spawner.spawn(net_task(runner).unwrap());


### PR DESCRIPTION
Replace icmp flag that got removed during package update. Move power gates into tasks so they don't block the executor task. Update power gate voltage ranges to accept off spec voltages