### PR TITLE
Wifi power on init delay, try send instead of send for motor commands

### DIFF
--- a/mote-firmware/src/main.rs
+++ b/mote-firmware/src/main.rs
@@ -17,6 +17,7 @@ use embassy_executor::{Executor, Spawner};
 use embassy_rp::clocks::{ClockConfig, CoreVoltage, clk_sys_freq};
 use embassy_rp::config::Config;
 use embassy_rp::multicore::{Stack, spawn_core1};
+use embassy_time::Timer;
 use embedded_alloc::LlffHeap as Heap;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
@@ -99,6 +100,7 @@ async fn core0_task(spawner: Spawner, r: Cyw43Resources, flash_r: FlashResources
     spawner.spawn(flash_manager::flash_manager_task(flash_r).unwrap());
     info!("Flash INIT complete");
 
+    Timer::after_millis(1000).await;
     wifi::init(spawner, r).await;
     info!("Wifi INIT complete");
 }

--- a/mote-firmware/src/tasks/wifi/udp_server.rs
+++ b/mote-firmware/src/tasks/wifi/udp_server.rs
@@ -22,7 +22,7 @@ async fn handle_command(rx_message: host_to_mote::Message, link: &mut HostLink) 
             info!("Received ping response from host.");
         }
         host_to_mote::Message::DriveBaseCommand(cmd) => {
-            MOTOR_COMMAND_CHANNEL.send(cmd).await;
+            let _ = MOTOR_COMMAND_CHANNEL.try_send(cmd);
         }
         _ => {
             error!("Received unhandled message type");


### PR DESCRIPTION
Fixes a power on wifi init failure + a bug that locked the wifi task when the drive base task was not emptying the command queue.