### PR TITLE
Lower power requirements to 1.5A

### DIFF
--- a/mote-firmware/src/tasks/drive_base.rs
+++ b/mote-firmware/src/tasks/drive_base.rs
@@ -116,7 +116,7 @@ async fn motor_task(
     right_encoder_r: RightEncoderResources,
     motor_driver_r: DRV8833Resources,
 ) {
-    info!("Gating on 3A capable before starting drive base");
+    info!("Gating on 1.5A capable before starting drive base");
     power_gate::gate_1_5_amp().await;
     info!("Power supply is 1.5A capable");
 

--- a/mote-firmware/src/tasks/drive_base.rs
+++ b/mote-firmware/src/tasks/drive_base.rs
@@ -117,8 +117,8 @@ async fn motor_task(
     motor_driver_r: DRV8833Resources,
 ) {
     info!("Gating on 3A capable before starting drive base");
-    power_gate::gate_3_amp().await;
-    info!("Power supply is 3A capable");
+    power_gate::gate_1_5_amp().await;
+    info!("Power supply is 1.5A capable");
 
     // Setup PWM
     let desired_freq_hz = 25_000;

--- a/mote-firmware/src/tasks/power_gate.rs
+++ b/mote-firmware/src/tasks/power_gate.rs
@@ -47,14 +47,10 @@ async fn power_gate_task(r: UsbPowerDetectionResources) -> ! {
             result: BITResult::Pass,
         };
         let comms_power = BIT {
-            name: "7.5W Capable (enables WIFI)".into(),
+            name: "7.5W Capable (enables WIFI and motors)".into(),
             result: BITResult::Waiting,
         };
-        let motor_power = BIT {
-            name: "15W Capable (enables drive base)".into(),
-            result: BITResult::Waiting,
-        };
-        for test in [init, comms_power, motor_power] {
+        for test in [init, comms_power] {
             configuration_state.built_in_test.power.push(test);
         }
     }
@@ -93,22 +89,13 @@ async fn power_gate_task(r: UsbPowerDetectionResources) -> ! {
             {
                 let mut configuration_state = CONFIGURATION_STATE.lock().await;
                 let mut wifi_pass = BITResult::Fail;
-                let mut drive_base_pass = BITResult::Fail;
                 if state == PowerState::Max1_5a || state == PowerState::Max3a {
                     wifi_pass = BITResult::Pass;
-                    if state == PowerState::Max3a {
-                        drive_base_pass = BITResult::Pass;
-                    }
                 };
                 update_bit_result(
                     &mut configuration_state.built_in_test.power,
-                    "7.5W Capable (enables WIFI)",
+                    "7.5W Capable (enables WIFI and motors)",
                     wifi_pass,
-                );
-                update_bit_result(
-                    &mut configuration_state.built_in_test.power,
-                    "15W Capable (enables drive base)",
-                    drive_base_pass,
                 );
             }
         }


### PR DESCRIPTION
Testing shows that power draw with wifi, lidar, and motors active peaks at ~1.2A. We are safe to enable all peripherals if the power source signals it is 1.5A (7.5W) capable.