### PR TITLE
Make imu NED frame consistent

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 skip = .git,*.lock,package-lock.json,*/node_modules/*,*/build/*,*/dist/*,*/target/*,*/.venv/*,*/book/*,*/styles/*,*/jlcpcb/*,fp-info-cache,ibom.html,*.svg,*.png,*.jpg,*.jpeg,*.pdf,*.woff,*.woff2,*.ttf,*.kicad_pcb,*.kicad_sch
-ignore-words-list = mote,ser
+ignore-words-list = mote,ser,NED
 check-hidden = true

--- a/mote-book/src/README.md
+++ b/mote-book/src/README.md
@@ -8,18 +8,10 @@ A low-cost, high-confidence mobile robot for hands-on robotics education.
 
 * LiDAR, IMU, and wheel position data streamed over WiFi
 * Polished SDKs for ROS, ROS2, Python and Rust
-* Wide platform support
-* Completely open source, forever
-* ~$100 all parts included
-
-Mote is supported by Cornell University's [EmPRISE Lab](https://empriselab.github.io/).
+* Wide cross-platform support
+* Open source firmware, software, and hardware
+* Only $100
 
 ## Getting Started
 
-Want to build your own Mote? Check out [the hardware sourcing guide](./hardware-sourcing/acquire.md).
-
-Already have a Mote? Get started by [assembling your kit](./getting_started/kit-assembly.md).
-
-Want to reconfigure your Mote? Go to the [configuration page](./configuration).
-
-Would like to contribute to the project? Read the [contribution guide](./advanced/contributing/contributing.md).
+See [assembling your kit](./getting_started/kit-assembly.md) if you already have your parts, or the [hardware sourcing guide](./hardware-sourcing/acquire.md) if you're working from scratch.

--- a/mote-book/src/getting_started/updating.md
+++ b/mote-book/src/getting_started/updating.md
@@ -1,6 +1,6 @@
 # Updating Firmware
 
-Before you can using your Mote, you must program the microcontroller on board the robot with the latest firmware.
+Before you can start using your Mote you'll need to program it with the latest firmware.
 
 1. Download the latest version of mote-firmware: [MOTE_FW_TAG_PLACEHOLDER](MOTE_FW_URL_PLACEHOLDER).
 

--- a/mote-firmware/src/tasks/imu.rs
+++ b/mote-firmware/src/tasks/imu.rs
@@ -47,7 +47,7 @@ pub async fn get_sensor_data(
                 let gyro = ImuAxisTriple {
                     x: gyro_tuple.0,
                     y: gyro_tuple.1,
-                    z: gyro_tuple.2,
+                    z: -gyro_tuple.2, // Negative corrects for NED sign conventions
                 };
 
                 // Return the temperature and the combined measurement


### PR DESCRIPTION
For some reason the IMU driver lib has the z-axis flipped. Invert this manually in our driver shim.